### PR TITLE
[backport release-v0.41.x] Backport coolk doc features to 0.40x

### DIFF
--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -421,6 +421,7 @@ The CEL evaluator is only useful for admins, since the payload and headers as se
 `tkn pac cel` — Evaluate CEL (Common Expression Language) expressions interactively with webhook payloads.
 
 This command allows you to test and debug CEL expressions as they would be evaluated by Pipelines-as-Code, using real webhook payloads and headers. It supports interactive and non-interactive modes, provider auto-detection, and persistent history.
+Note that the CEL evaluator may not always produce the same output as when the expression is evaluated in an actual PipelineRun.
 
 To be able to have the CEL evaluator working, you need to have the payload and the headers available in a file. The best way to do this is to go to the webhook configuration on your git provider and copy the payload and headers to different files.
 

--- a/pkg/cmd/tknpac/cel/cel.go
+++ b/pkg/cmd/tknpac/cel/cel.go
@@ -81,8 +81,10 @@ func printBanner(ioStreams *cli.IOStreams, provider, bodyFile, headersFile strin
 
 	fmt.Fprintf(ioStreams.Out, "%s %s\n", cs.Yellow("⚠"), cs.Bold("Important Notice"))
 	fmt.Fprint(ioStreams.Out, "\n")
-	fmt.Fprintf(ioStreams.Out, "This tool provides an interactive environment for testing CEL expressions.\n")
-	fmt.Fprintf(ioStreams.Out, "However, please note the following important differences:\n")
+	fmt.Fprintf(ioStreams.Out, "This is a %s feature for testing CEL expressions.\n", cs.Yellow("tech preview"))
+	fmt.Fprintf(ioStreams.Out, "%s\n", cs.Bold("The evaluator may not always produce the same output as in actual PipelineRuns."))
+	fmt.Fprint(ioStreams.Out, "\n")
+	fmt.Fprintf(ioStreams.Out, "Please note the following important differences:\n")
 	fmt.Fprint(ioStreams.Out, "\n")
 
 	differences := []string{


### PR DESCRIPTION
Automated backport PR.

- Source issue: https://github.com/chmouel/scratchmyback/issues/401
- Target branch: `release-v0.41.x`
- Cherry-picked commits:
  - `1ae4c376c47c9842d209bd23dd25925e7eb8caf9`